### PR TITLE
Improved index controller bindings

### DIFF
--- a/actions_binding_knuckles.json
+++ b/actions_binding_knuckles.json
@@ -197,7 +197,11 @@
                      "output" : "/actions/default/in/click"
                   }
                },
-               "mode" : "trigger",
+               "mode" : "button",
+               "parameters" : {
+                  "click_activate_threshold" : "0.35",
+                  "click_deactivate_threshold" : "0.31"
+               },
                "path" : "/user/hand/left/input/trigger"
             },
             {
@@ -206,7 +210,11 @@
                      "output" : "/actions/default/in/click"
                   }
                },
-               "mode" : "trigger",
+               "mode" : "button",
+               "parameters" : {
+                  "click_activate_threshold" : "0.35",
+                  "click_deactivate_threshold" : "0.31"
+               },
                "path" : "/user/hand/right/input/trigger"
             },
             {
@@ -235,8 +243,8 @@
                },
                "mode" : "grab",
                "parameters" : {
-                  "value_hold_threshold" : "1.9",
-                  "value_release_threshold" : "1.2"
+                  "value_hold_threshold" : "1.3",
+                  "value_release_threshold" : "1.1"
                },
                "path" : "/user/hand/left/input/grip"
             },
@@ -248,8 +256,8 @@
                },
                "mode" : "grab",
                "parameters" : {
-                  "value_hold_threshold" : "1.9",
-                  "value_release_threshold" : "1.2"
+                  "value_hold_threshold" : "1.3",
+                  "value_release_threshold" : "1.1"
                },
                "path" : "/user/hand/right/input/grip"
             },


### PR DESCRIPTION
Hello!
I just finished testing this overlay and this tool improves QoL on Linux with SteamVR drastically, it's basically invaluable. Far easier to install/use than something like xrdesktop.
I have index controllers, so i gave it a try and noticed that some thing could be improved. 
Like, instead of full clicking (which is an actual click with a button on index) you can pull it slightly and it will act like a click. Highly improves text writing speed and gives a nice non-interrupted rumble. This change can be potentially copied over to touch controllers too, so it will require less force to do so too. 
And i reduced grip/grab strength required to move window around because pressure sensor on index controllers is rather hard to grip and you certainly don't want to death grip them.

Have a nice day and further contributions!