### PR TITLE
X11 screens need names in the contructor

### DIFF
--- a/Desktop/BaseOutput.cs
+++ b/Desktop/BaseOutput.cs
@@ -7,6 +7,11 @@ public class BaseOutput
     public string Name { get; set; } = null!;
     public Vector2Int Position { get; set; }
     public Vector2Int Size { get; set; }
+    
+    public BaseOutput() { }
+    public BaseOutput(string name) {
+        Name = name;
+    }
 
     public override string ToString()
     {

--- a/Overlays/XorgScreen.cs
+++ b/Overlays/XorgScreen.cs
@@ -23,7 +23,7 @@ public class XorgScreen : BaseScreen<BaseOutput>
     private readonly IntPtr _handle;
     private readonly uint _bufSize;
 
-    public XorgScreen(int screen) : base(new BaseOutput())
+    public XorgScreen(int screen) : base(new BaseOutput(screen.ToString()))
     {
         Vector2Int size = new(), pos = new();
 


### PR DESCRIPTION
Overlay key is set in BaseOverlay constructor, and X11 screens weren't giving it a name early enough.

Fixes #5