### PR TITLE
use pkgconfig for wlxpw

### DIFF
--- a/lib/wlxpw/CMakeLists.txt
+++ b/lib/wlxpw/CMakeLists.txt
@@ -3,8 +3,12 @@ project(wlxpw C)
 
 set(CMAKE_C_STANDARD 17)
 
+find_package(PkgConfig REQUIRED)
+
+pkg_check_modules(WLXPWLIBS REQUIRED IMPORTED_TARGET libpipewire-0.3 libspa-0.2)
+
 add_library(wlxpw SHARED library.c)
 
 target_link_libraries(wlxpw
-        libpipewire-0.3.so)
+        PkgConfig::WLXPWLIBS)
         


### PR DESCRIPTION
This should make it so that libpipewire & libspa are more reliably found on various distros.

Tested on Arch.