### PR TITLE
use cmake --build instead of make

### DIFF
--- a/prebuild.sh
+++ b/prebuild.sh
@@ -4,12 +4,12 @@ git describe --tags --dirty --always > Resources/version.txt
 
 cd lib/wlxpw || exit 1
 cmake .
-make
+cmake --build .
 mv libwlxpw.so ../../
 cd ../..
 
 cd lib/wlxshm || exit 1
 cmake .
-make
+cmake --build .
 mv libwlxshm.so ../../
 cd ../..


### PR DESCRIPTION
Allows people to have `CMAKE_GENERATOR` set and still build, as some may globally set this to `Ninja`.