### PR TITLE
Make EGL context, required for dma_buf on mesa

### DIFF
--- a/Desktop/EGL.cs
+++ b/Desktop/EGL.cs
@@ -1,3 +1,4 @@
+using Silk.NET.GLFW;
 using System.Runtime.InteropServices;
 
 // ReSharper disable InconsistentNaming
@@ -45,6 +46,8 @@ public static class EGL
 
         if (Initialize(Display, out var major, out var minor) == EglEnum.False)
             throw new ApplicationException("eglInitialize returned EGL_FALSE!");
+
+        GlfwProvider.GLFW.Value.WindowHint(WindowHintContextApi.ContextCreationApi, ContextApi.EglContextApi);
 
         Console.WriteLine($"EGL {major}.{minor} initialized.");
     }


### PR DESCRIPTION
Only tested on my machine, hopefully it doesn't break nVidia

The pipewire dma still crashes, but with a different error. DmaBuf is better, so I won't look into it, but here's the log anyway:
```
Unhandled exception. System.ApplicationException: BadAlloc on eglCreateImage!
   at WlxOverlay.Desktop.Pipewire.PipeWireCapture.ApplyToTexture(ITexture texture) in /home/chris/Downloads/VR/Tools/WlxOverlay/Desktop/Pipewire/PipeWireCapture.cs:line 134
   at WlxOverlay.Overlays.Wayland.PipeWireScreen.Render() in /home/chris/Downloads/VR/Tools/WlxOverlay/Overlays/Wayland/PipeWireScreen.cs:line 40
   at WlxOverlay.Core.OverlayManager.Update() in /home/chris/Downloads/VR/Tools/WlxOverlay/Core/OverlayManager.cs:line 190
   at WlxOverlay.GFX.OpenGL.GlGraphicsEngine.OnRender(Double _) in /home/chris/Downloads/VR/Tools/WlxOverlay/GFX/OpenGL/GlGraphicsEngine.cs:line 71
   at Silk.NET.Windowing.Internals.ViewImplementationBase.DoRender()
   at Silk.NET.Windowing.Internals.ViewImplementationBase.Run(Action onFrame)
   at Silk.NET.Windowing.WindowExtensions.Run(IView view)
   at WlxOverlay.GFX.OpenGL.GlGraphicsEngine.StartEventLoop() in /home/chris/Downloads/VR/Tools/WlxOverlay/GFX/OpenGL/GlGraphicsEngine.cs:line 44
   at Program.<Main>$(String[] args) in /home/chris/Downloads/VR/Tools/WlxOverlay/Program.cs:line 113
   at Program.<Main>(String[] args)

```