### PR TITLE
Swap the up and down actions for PTT

### DIFF
--- a/Extras/PttHandler.cs
+++ b/Extras/PttHandler.cs
@@ -21,13 +21,13 @@ public static class PttHandler
 
             if (!args.Before.AltClick && args.Now.AltClick)
             {
-                if (upStart != null)
-                    Process.Start(upStart);
+                if (dnStart != null)
+                    Process.Start(dnStart);
             }
             else if (args.Before.AltClick && !args.Now.AltClick)
             {
-                if (dnStart != null)
-                    Process.Start(dnStart);
+                if (upStart != null)
+                    Process.Start(upStart);
             }
 
             return InteractionResult.OK;


### PR DESCRIPTION
Currently the state `("not clicked before" && "clicked now")` triggers the "up" action, and `("clicked before" && "not clicked now")` triggers the "down" action.
To me, this seems backwards for a button, so I've swapped the up/dn actions.